### PR TITLE
2839185 inject config factory

### DIFF
--- a/commerce_stock.services.yml
+++ b/commerce_stock.services.yml
@@ -9,6 +9,7 @@ services:
     class: Drupal\commerce_stock\StockServiceManager
     tags:
       - { name: service_collector, tag: commerce_stock.stock_service, call: addService }
+    arguments: [ '@config.factory' ]
 
   commerce_stock.always_in_stock_service:
     class: Drupal\commerce_stock\AlwaysInStockService

--- a/src/StockServiceManager.php
+++ b/src/StockServiceManager.php
@@ -49,12 +49,14 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
    * {@inheritdoc}
    */
   public function getService(PurchasableEntityInterface $entity) {
-    $default_service_id = $this->configFactory->get('commerce_stock.service_manager')->get('default_service_id');
+    $config = $this->configFactory->get('commerce_stock.service_manager');
+
+    $default_service_id = $config->get('default_service_id');
 
     $entity_type = $entity->getEntityType()->id();
     $entity_bundle = $entity->bundle();
     $entity_config_key = $entity_type . '_' . $entity_bundle . '_service_id';
-    $entity_service_id = $this->configFactory->get('commerce_stock.service_manager')->get($entity_config_key);
+    $entity_service_id = $config->get($entity_config_key);
 
     $service_id = $entity_service_id ?: $default_service_id;
 

--- a/src/StockServiceManager.php
+++ b/src/StockServiceManager.php
@@ -3,6 +3,7 @@
 namespace Drupal\commerce_stock;
 
 use Drupal\commerce\PurchasableEntityInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 
 /**
  * The stock service manager, responsible for handling services and transactions.
@@ -21,6 +22,23 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
   protected $stockServices = [];
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a StockServiceManager object.
+   *
+   * @param ConfigFactoryInterface $config_factory
+   *    The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function addService(StockServiceInterface $stock_service) {
@@ -31,12 +49,13 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
    * {@inheritdoc}
    */
   public function getService(PurchasableEntityInterface $entity) {
-    $config = \Drupal::config('commerce_stock.service_manager');
-    $default_service_id = $config->get('default_service_id');
+    $default_service_id = $this->configFactory->get('commerce_stock.service_manager')->get('default_service_id');
+
     $entity_type = $entity->getEntityType()->id();
     $entity_bundle = $entity->bundle();
     $entity_config_key = $entity_type . '_' . $entity_bundle . '_service_id';
-    $entity_service_id = $config->get($entity_config_key);
+    $entity_service_id = $this->configFactory->get('commerce_stock.service_manager')->get($entity_config_key);
+
     $service_id = $entity_service_id ?: $default_service_id;
 
     return $this->stockServices[$service_id];

--- a/tests/src/Unit/StockServiceManagerTest.php
+++ b/tests/src/Unit/StockServiceManagerTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\commerce_stock\Unit;
 
 use Drupal\commerce_stock\StockServiceManager;
 use Drupal\Tests\UnitTestCase;
-use Prophecy\Argument;
+
 
 /**
  * @coversDefaultClass \Drupal\commerce_stock\StockServiceManager

--- a/tests/src/Unit/StockServiceManagerTest.php
+++ b/tests/src/Unit/StockServiceManagerTest.php
@@ -5,7 +5,6 @@ namespace Drupal\Tests\commerce_stock\Unit;
 use Drupal\commerce_stock\StockServiceManager;
 use Drupal\Tests\UnitTestCase;
 
-
 /**
  * @coversDefaultClass \Drupal\commerce_stock\StockServiceManager
  * @group commerce_stock

--- a/tests/src/Unit/StockServiceManagerTest.php
+++ b/tests/src/Unit/StockServiceManagerTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\commerce_stock\Unit;
 
 use Drupal\commerce_stock\StockServiceManager;
 use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
 
 /**
  * @coversDefaultClass \Drupal\commerce_stock\StockServiceManager
@@ -23,7 +24,9 @@ class StockServiceManagerTest extends UnitTestCase {
    */
   public function setUp() {
     parent::setUp();
-    $this->stockServiceManager = new StockServiceManager();
+
+    $configFactory = $this->prophesize('\Drupal\Core\Config\ConfigFactory');
+    $this->stockServiceManager = new StockServiceManager($configFactory->reveal());
   }
 
   /**


### PR DESCRIPTION
[Issue 2839185](https://www.drupal.org/node/2839185): Injects a the config factory service in the StockServiceManager instead of calling Drupal:: directly during construction time. Refactores the getService() method to use the configFactory.

Needs the PR #2 from steveoliver for the tests.