### PR TITLE
2865552 fix stock service locations list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 
     # The environment to use, supported are: drupal-7, drupal-8
     - DRUPAL_TI_ENVIRONMENT="drupal-8"
-    - DRUPAL_TI_CORE_BRANCH="8.2.x"
+    - DRUPAL_TI_CORE_BRANCH="8.3.x"
 
     # Drupal specific variables.
     - DRUPAL_TI_DB="drupal_travis_db"

--- a/modules/local_storage/src/LocalStockChecker.php
+++ b/modules/local_storage/src/LocalStockChecker.php
@@ -157,8 +157,8 @@ class LocalStockChecker implements StockCheckInterface {
    *
    * @param \Drupal\commerce\PurchasableEntityInterface $entity
    *   The purchasable entity.
-   * @param array $locations
-   *   Array of locations ids.
+   * @param \Drupal\commerce_stock\StockLocationInterface[] $locations
+   *   The stock locations.
    *
    * @return array
    *   Stock level information indexed by location id with these values:
@@ -167,6 +167,7 @@ class LocalStockChecker implements StockCheckInterface {
    */
   public function getLocationsStockLevels(PurchasableEntityInterface $entity, array $locations) {
     $location_levels = [];
+    /** @var \Drupal\commerce_stock\StockLocationInterface $location */
     foreach ($locations as $location) {
       $location_id = $location->getId();
       $location_level = $this->getLocationStockLevel($location_id, $entity);

--- a/src/StockServiceConfig.php
+++ b/src/StockServiceConfig.php
@@ -63,7 +63,7 @@ class StockServiceConfig implements StockServiceConfigInterface {
     $locations = $this->stockChecker->getLocationList(TRUE);
     $this->stockLocations = [];
     foreach ($locations as $key => $value) {
-      $this->stockLocations[$key] = $key;
+      $this->stockLocations[$key] = $value;
     }
   }
 

--- a/tests/src/Kernel/StockServiceConfigTest.php
+++ b/tests/src/Kernel/StockServiceConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\Tests\commerce_stock\Kernel;
+
+use Drupal\commerce\PurchasableEntityInterface;
+use Drupal\commerce_stock\StockCheckInterface;
+use Drupal\commerce_stock\StockLocationInterface;
+use Drupal\commerce_stock\StockServiceConfig;
+use Prophecy\Argument;
+
+/**
+ * Tests the stock service configuration.
+ *
+ * @coversDefaultClass \Drupal\commerce_stock\StockServiceConfig
+ *
+ * @group commerce_stock
+ */
+class StockServiceConfigTest extends CommerceStockKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installConfig(['commerce_stock']);
+  }
+
+  /**
+   * @covers ::getLocationList
+   * @covers ::loadConfiguration
+   * @covers ::getPrimaryTransactionLocation
+   */
+  public function testLocalStockService() {
+
+    $locations = [];
+
+    for($i = 1; $i < 4; $i++){
+      $prophecy = $this->prophesize(StockLocationInterface::class);
+      $prophecy->getId()->willReturn($i);
+      $prophecy->isActive()->willReturn(true);
+      $locations[] =  $prophecy->reveal();
+    }
+
+    $prophecy = $this->prophesize(StockCheckInterface::class);
+    $prophecy->getLocationList(Argument::is(true))->willReturn($locations);
+    $stockChecker = $prophecy->reveal();
+
+    $stockServiceConfig = new StockServiceConfig($stockChecker);
+
+    $prophecy = $this->prophesize(PurchasableEntityInterface::class);
+    $entity = $prophecy->reveal();
+
+    // Test that getLocationList() returns active location entities.
+    $locations = $stockServiceConfig->getLocationList($entity);
+    self::assertEquals(3, count($locations));
+    foreach($locations as $location){
+      self::assertInstanceOf('Drupal\commerce_stock\StockLocationInterface', $location);
+      self::assertTrue($location->isActive());
+    }
+
+    // Test that getPrimaryTransactionLocation() returns one active location entity.
+    $primary = $stockServiceConfig->getPrimaryTransactionLocation($entity, 1);
+    self::assertInstanceOf('Drupal\commerce_stock\StockLocationInterface', $primary);
+    self::assertTrue($primary->isActive());
+
+  }
+
+}

--- a/tests/src/Kernel/StockServiceConfigTest.php
+++ b/tests/src/Kernel/StockServiceConfigTest.php
@@ -34,15 +34,15 @@ class StockServiceConfigTest extends CommerceStockKernelTestBase {
 
     $locations = [];
 
-    for($i = 1; $i < 4; $i++){
+    for ($i = 1; $i < 4; $i++) {
       $prophecy = $this->prophesize(StockLocationInterface::class);
       $prophecy->getId()->willReturn($i);
-      $prophecy->isActive()->willReturn(true);
-      $locations[] =  $prophecy->reveal();
+      $prophecy->isActive()->willReturn(TRUE);
+      $locations[] = $prophecy->reveal();
     }
 
     $prophecy = $this->prophesize(StockCheckInterface::class);
-    $prophecy->getLocationList(Argument::is(true))->willReturn($locations);
+    $prophecy->getLocationList(Argument::is(TRUE))->willReturn($locations);
     $stockChecker = $prophecy->reveal();
 
     $stockServiceConfig = new StockServiceConfig($stockChecker);
@@ -53,7 +53,7 @@ class StockServiceConfigTest extends CommerceStockKernelTestBase {
     // Test that getLocationList() returns active location entities.
     $locations = $stockServiceConfig->getLocationList($entity);
     self::assertEquals(3, count($locations));
-    foreach($locations as $location){
+    foreach ($locations as $location) {
       self::assertInstanceOf('Drupal\commerce_stock\StockLocationInterface', $location);
       self::assertTrue($location->isActive());
     }


### PR DESCRIPTION
Three commits. One for the doc comment follow up, one for the test follow up and one for the fix. @BBGuy If you are fine with the refactoring from @steveoliver, please go with it and cherry-pick [8ae1679](https://github.com/olafkarsten/commerce_stock/commit/8ae16791c33e39409f4c6ae00c3f48c0ca8fcd57) for the doc comment fix and [b490ff5](https://github.com/BBGuy/commerce_stock/pull/33/commits/b490ff593aecdb160215244016b5e37ed9543063) for the tests.

And BTW we first should get (PR30)[https://github.com/BBGuy/commerce_stock/pull/30] in and fix the annoying build fails.