### PR TITLE
Issue #2847529: check stock availability in add-to-cart form and alter button

### DIFF
--- a/modules/local_storage/commerce_stock_local.module
+++ b/modules/local_storage/commerce_stock_local.module
@@ -8,6 +8,43 @@
 use Drupal\Core\Render\Element;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\commerce_product\Entity\ProductVariation;
+
+/**
+ * Implements hook_form_alter().
+ */
+function commerce_stock_local_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (strpos($form_id, 'commerce_order_item_add_to_cart_form') === 0) {
+    /** @var \Drupal\commerce_cart\Form\AddToCartForm $form_object */
+    $form_object = $form_state->getBuildInfo()['callback_object'];
+
+    $storage = $form_state->getStorage();
+    if (isset($storage['selected_variation'])) {
+      $variation = ProductVariation::load($storage['selected_variation']);
+    } else {
+      $order_item = $form_object->getEntity();
+      $variation = $order_item->getPurchasedEntity();
+    }
+
+    if (empty($variation)) return;
+
+    $stores = $variation->getStores();
+    if (count($stores) === 0) {
+      throw new \Exception('The given entity is not assigned to any store.');
+    }
+    $store = reset($stores);
+    $context = new Context($form_object->getCurrentUser(), $store);
+    /** @var \Drupal\commerce\AvailabilityResponse $availability */
+    $availability = $form_object->getAvailabilityManager()->check($variation, 1, $context);
+
+    if ($availability->isUnavailable()) {
+      $form['actions']['submit']['#value'] = t('Unavailable');
+      $form['actions']['submit']['#attributes'] = [
+        'disabled' => 'disabled',
+      ];
+    }
+  }
+}
 
 /**
  * Implements hook_entity_base_field_info().

--- a/modules/local_storage/commerce_stock_local.module
+++ b/modules/local_storage/commerce_stock_local.module
@@ -9,11 +9,13 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\Core\Form\FormState;
+use Drupal\commerce\Context;
 
 /**
  * Implements hook_form_alter().
  */
-function commerce_stock_local_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function commerce_stock_local_form_alter(&$form, FormState $form_state, $form_id) {
   if (strpos($form_id, 'commerce_order_item_add_to_cart_form') === 0) {
     /** @var \Drupal\commerce_cart\Form\AddToCartForm $form_object */
     $form_object = $form_state->getBuildInfo()['callback_object'];


### PR DESCRIPTION
This PR only works if commerce is patched with https://github.com/drupalcommerce/commerce/pull/593 

This hook_form_alter in commerce_stock_local.module addresses several problems:

1) the base AddToCartForm does not check availability, therefore always allows clicking "Add to Cart" even if not available.  PR will check availability and disable button, changing button text to "Unavailable". This will work with whatever stock checker is in use (e.g. commerce_stock_backorderable which overrides the default checker). 

2)  hook_form_alter AddToCart form object only gives the default purchaseable entity when loading the form via ajax or using query params (product/1?v=2), but if the form uses attributes to select the variation, there is a "selected_variation" storage key that we can use to load the correct variation. 