### PR TITLE
removed duplicate

### DIFF
--- a/commerce_stock.services.yml
+++ b/commerce_stock.services.yml
@@ -24,6 +24,3 @@ services:
   plugin.manager.stock_events:
     class: Drupal\commerce_stock\Plugin\StockEventsManager
     parent: default_plugin_manager
-  plugin.manager.stock_events:
-    class: Drupal\commerce_stock\StockEventsManager
-    arguments: ['@module_handler', '@cache.discovery']


### PR DESCRIPTION
Under commerce_stock.services.yml file, plugin.manager.stock_events plugin is listed twice. This lead to the missing plugin list on the stock event handler configuration.