### PR TITLE
Issue #2953826 by olafkarsten: Adds missing script file for running t…

### DIFF
--- a/.travis-simpletest-js.sh
+++ b/.travis-simpletest-js.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# @file
+# Simple script to run the tests via travis-ci.
+
+set -e $DRUPAL_TI_DEBUG
+
+export ARGS=( $DRUPAL_TI_SIMPLETEST_JS_ARGS )
+
+if [ -n "$DRUPAL_TI_SIMPLETEST_GROUP" ]
+then
+        ARGS=( "${ARGS[@]}" "$DRUPAL_TI_SIMPLETEST_GROUP" )
+fi
+
+
+cd "$DRUPAL_TI_DRUPAL_DIR"
+{ php "$DRUPAL_TI_SIMPLETEST_FILE" --php $(which php) "${ARGS[@]}" || echo "1 fails"; } | tee /tmp/simpletest-result.txt
+
+egrep -i "([1-9]+ fail[s]?)|(Fatal error)|([1-9]+ exception[s]?)" /tmp/simpletest-result.txt && exit 1
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 
     # The environment to use, supported are: drupal-7, drupal-8
     - DRUPAL_TI_ENVIRONMENT="drupal-8"
-    - DRUPAL_TI_CORE_BRANCH="8.4.x"
+    - DRUPAL_TI_CORE_BRANCH="8.5.x"
 
     # Drupal specific variables.
     - DRUPAL_TI_DB="drupal_travis_db"
@@ -51,8 +51,8 @@ env:
     - DRUPAL_TI_WEBSERVER_PORT="8080"
 
     # Simpletest specific commandline arguments, the DRUPAL_TI_SIMPLETEST_GROUP is appended at the end.
-    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 20 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types Simpletest,PHPUnit-Unit,PHPUnit-Kernel,PHPUnit-Functional"
-    - DRUPAL_TI_SIMPLETEST_JS_ARGS="--verbose --color --concurrency 1 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types PHPUnit-FunctionalJavascript"
+    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 20 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types Simpletest,PHPUnit-Unit,PHPUnit-Kernel,PHPUnit-Functional --suppress-deprecations"
+    - DRUPAL_TI_SIMPLETEST_JS_ARGS="--verbose --color --concurrency 1 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT --types PHPUnit-FunctionalJavascript --suppress-deprecations"
 
     # === Behat specific variables.
     # This is relative to $TRAVIS_BUILD_DIR
@@ -126,9 +126,9 @@ script:
   - phpcs --standard=phpcs.xml src -s
   - phpcs --standard=phpcs.xml modules -s
   - phpcs --standard=phpcs.xml tests -s
-  - phpcs --standard=phpcs.xml commerce.module
+
   - drupal-ti script
-  - drupal-ti --include ".travis-simpletest-js.sh"
+  #- drupal-ti --include ".travis-simpletest-js.sh"
 
 after_script:
   - drupal-ti after_script


### PR DESCRIPTION
…he functional javascript tests. We don't need that today, but will need it in a couple of days. Bumps up core requirement to 8.5.

This one fixes the broken build process on travis an bumps up the core version to 8.5. It prepares us for using functional javascript tests, too.

Note: this will not fix any issues with code sniffer and failing tests. But It gives us travis back to fix all these issues.