### PR TITLE
2738807 stabilize level field

### DIFF
--- a/modules/field/src/Plugin/Field/FieldType/StockLevel.php
+++ b/modules/field/src/Plugin/Field/FieldType/StockLevel.php
@@ -77,7 +77,7 @@ class StockLevel extends FieldItemBase {
     // Supports absolute values being passed in directly, i.e.
     // programmatically.
     if (!is_array($values)) {
-      $value = filter_var($values, FILTER_VALIDATE_INT);
+      $value = filter_var($values, FILTER_VALIDATE_FLOAT);
       if ($value) {
         $values = ['stock' => ['value' => $value]];
       }

--- a/modules/field/src/Plugin/Field/FieldType/StockLevel.php
+++ b/modules/field/src/Plugin/Field/FieldType/StockLevel.php
@@ -6,8 +6,6 @@ use Drupal\commerce_stock\StockTransactionsInterface;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\TypedData\DataDefinition;
-use Drupal\Core\TypedData\DataDefinitionInterface;
-use Drupal\Core\TypedData\TypedDataInterface;
 
 /**
  * Plugin implementation of the 'commerce_stock_field' field type.
@@ -22,21 +20,6 @@ use Drupal\Core\TypedData\TypedDataInterface;
  * )
  */
 class StockLevel extends FieldItemBase {
-
-  /**
-   * The stock service manager.
-   *
-   * @var \Drupal\commerce_stock\StockServiceManager
-   */
-  protected $stockServiceManager;
-
-  /**
-   * {@inheritdoc}
-   */
-  public function __construct(DataDefinitionInterface $definition, $name = NULL, TypedDataInterface $parent = NULL) {
-    parent::__construct($definition, $name, $parent);
-    $this->stockServiceManager = \Drupal::service('commerce_stock.service_manager');
-  }
 
   /**
    * {@inheritdoc}
@@ -91,13 +74,20 @@ class StockLevel extends FieldItemBase {
   public function setValue($values, $notify = TRUE) {
     static $called = [];
 
-    // If no stock data.
-    if (!isset($values['stock'])) {
-      // Nothing to do.
-      return;
+    // Supports absolute values being passed in directly, i.e.
+    // programmatically.
+    if (!is_array($values)) {
+      $value = filter_var($values, FILTER_VALIDATE_INT);
+      if ($value) {
+        $values = ['stock' => ['value' => $value]];
+      }
+      else {
+        return;
+      }
     }
 
     if (!empty($this->getEntity())) {
+      $stockServiceManager = \Drupal::service('commerce_stock.service_manager');
       $entity = $this->getEntity();
       if (empty($entity->id())) {
         return;
@@ -109,27 +99,23 @@ class StockLevel extends FieldItemBase {
       $called[$entity->getEntityTypeId() . $entity->id()] = TRUE;
       $transaction_qty = 0;
 
-      // Supports absolute values being passed in directly, i.e.
-      // programmatically.
-      if (!is_array($values)) {
-        $values = ['stock' => ['value' => $values]];
-      }
-      if (empty($values['stock']['entry_system'])) {
-        $transaction_qty = (int) $values['stock']['value'];
-      }
+      if (isset($values['stock'])) {
+        if (empty($values['stock']['entry_system'])) {
+          $transaction_qty = (int) $values['stock']['value'];
+        }
+        // Or supports a field widget entry system.
+        else {
+          switch ($values['stock']['entry_system']) {
+            case 'simple':
+              $new_level = $values['stock']['value'];
+              $level = $stockServiceManager->getStockLevel($entity);
+              $transaction_qty = $new_level - $level;
+              break;
 
-      // Or supports a field widget entry system.
-      else {
-        switch ($values['stock']['entry_system']) {
-          case 'simple':
-            $new_level = $values['stock']['value'];
-            $level = $this->stockServiceManager->getStockLevel($entity);
-            $transaction_qty = $new_level - $level;
-            break;
-
-          case 'basic':
-            $transaction_qty = (int) $values['stock']['adjustment'];
-            break;
+            case 'basic':
+              $transaction_qty = (int) $values['stock']['adjustment'];
+              break;
+          }
         }
       }
 
@@ -137,7 +123,7 @@ class StockLevel extends FieldItemBase {
         $transaction_type = ($transaction_qty > 0) ? StockTransactionsInterface::STOCK_IN : StockTransactionsInterface::STOCK_OUT;
         // @todo Add zone and location to form.
         /** @var \Drupal\commerce_stock\StockLocationInterface $location */
-        $location = $this->stockServiceManager->getTransactionLocation($this->stockServiceManager->getContext($entity), $entity, $transaction_qty);
+        $location = $stockServiceManager->getTransactionLocation($stockServiceManager->getContext($entity), $entity, $transaction_qty);
         if (empty($location)) {
           // This shouldnever get called as we should always have a location.
           return;
@@ -148,7 +134,7 @@ class StockLevel extends FieldItemBase {
         // @ToDo Make this hardcoded note translatable or remove it at all.
         $transaction_note = isset($values['stock']['stock_transaction_note']) ? $values['stock']['stock_transaction_note'] : 'stock level set or updated by field';
         $metadata = ['data' => ['message' => $transaction_note]];
-        $this->stockServiceManager->createTransaction($entity, $location->getId(), $zone, $transaction_qty, $unit_cost, $transaction_type, $metadata);
+        $stockServiceManager->createTransaction($entity, $location->getId(), $zone, $transaction_qty, $unit_cost, $transaction_type, $metadata);
       }
     }
   }

--- a/modules/field/tests/src/Kernel/StockLevelTest.php
+++ b/modules/field/tests/src/Kernel/StockLevelTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Drupal\Tests\commerce_stock_field\Kernel;
+
+use Drupal\commerce\Context;
+use Drupal\commerce_product\Entity\ProductVariation;
+use Drupal\commerce_stock\StockTransactionsInterface;
+use Drupal\commerce_stock_local\Entity\StockLocation;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\commerce_stock\Kernel\CommerceStockKernelTestBase;
+
+/**
+ * Ensure the stock level field works.
+ *
+ * @coversDefaultClass \Drupal\commerce_stock_field\Plugin\Field\FieldType\StockLevel
+ *
+ * @group commerce_stock
+ */
+class StockLevelTest extends CommerceStockKernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'path',
+    'commerce_product',
+    'commerce_stock',
+    'commerce_stock_field',
+    'commerce_stock_local',
+  ];
+
+  /**
+   * A test variation.
+   *
+   * @var \Drupal\commerce_product\Entity\ProductVariationInterface
+   */
+  protected $variation;
+
+  /**
+   * The stock service manager.
+   *
+   * @var \Drupal\commerce_stock\StockServiceManagerInterface
+   */
+  protected $stockServiceManager;
+
+  /**
+   * The stock checker.
+   *
+   * @var \Drupal\commerce_stock\StockCheckInterface
+   */
+  protected $checker;
+
+  /**
+   * The stock service configuration.
+   *
+   * @var \Drupal\commerce_stock\stockServiceConfiguration
+   */
+  protected $stockServiceConfiguration;
+
+  /**
+   * An array of location ids for variation1.
+   *
+   * @var int[]
+   */
+  protected $locations;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('commerce_stock_location');
+    $this->installEntitySchema('commerce_product');
+    $this->installEntitySchema('commerce_product_variation');
+    $this->installConfig([
+      'commerce_product',
+      'commerce_stock',
+      'commerce_stock_local',
+    ]);
+    $this->installSchema(
+      'commerce_stock_local',
+      [
+        'commerce_stock_transaction',
+        'commerce_stock_transaction_type',
+        'commerce_stock_location_level',
+      ]);
+
+    $configFactory = $this->container->get('config.factory');
+    $config = $configFactory->getEditable('commerce_stock.service_manager');
+    $config->set('default_service_id', 'local_stock');
+    $config->save();
+    $this->stockServiceManager = \Drupal::service('commerce_stock.service_manager');
+
+    $location = StockLocation::create([
+      'type' => 'default',
+      'name' => $this->randomString(),
+      'status' => 1,
+    ]);
+    $location->save();
+
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => 'test_stock_level',
+      'entity_type' => 'commerce_product_variation',
+      'type' => 'commerce_stock_level',
+      'cardinality' => 1,
+    ]);
+    $field_storage->save();
+
+    $field = FieldConfig::create([
+      'field_name' => 'test_stock_level',
+      'entity_type' => 'commerce_product_variation',
+      'bundle' => 'default',
+    ]);
+    $field->save();
+
+    $variation = ProductVariation::create([
+      'type' => 'default',
+      'sku' => 'TEST_' . strtolower($this->randomMachineName()),
+      'status' => 1,
+      'price' => [
+        'number' => '12.00',
+        'currency_code' => 'USD',
+      ],
+    ]);
+    $variation->save();
+    $this->variation = $variation;
+
+    $user = $this->createUser(['mail' => $this->randomString() . '@example.com']);
+
+    $this->stockServiceManager->createTransaction($variation, 1, '', 55, 0, StockTransactionsInterface::STOCK_IN);
+
+    $this->checker = $this->stockServiceManager->getService($this->variation)
+      ->getStockChecker();
+    $this->stockServiceConfiguration = $this->stockServiceManager->getService($this->variation)
+      ->getConfiguration();
+    $context = new Context($user, $this->store);
+
+    $this->locations = $this->stockServiceConfiguration->getAvailabilityLocations($context, $this->variation);
+  }
+
+  /**
+   * Whether setting a plain value results in increased stock level.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testStockLevelStockIn() {
+    $this->variation->set('test_stock_level', 10);
+    $this->variation->save();
+    $this->assertEquals(65, $this->checker->getTotalStockLevel($this->variation, $this->locations));
+
+  }
+
+  /**
+   * Whether setting a plain negative results in reduced stock level.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testStockLevelStockOut() {
+    $this->variation->set('test_stock_level', -10);
+    $this->variation->save();
+    $this->assertEquals(45, $this->checker->getTotalStockLevel($this->variation, $this->locations));
+
+  }
+
+  /**
+   * Whether setting via simple entry system works and sets the absolute stock
+   * level.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testStockLevelSimpleEntry() {
+    $stubSimpleEntry = [
+      'stock' => [
+        'value' => 22,
+        'entry_system' => 'simple',
+      ],
+    ];
+    $this->variation->set('test_stock_level', $stubSimpleEntry);
+    $this->variation->save();
+    $this->assertEquals(22, $this->checker->getTotalStockLevel($this->variation, $this->locations));
+  }
+
+  /**
+   * Whether setting via basic entry system works. Positiv value should increase
+   * stock level.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testStockLevelBasicEntryStockIn() {
+    $stubBasicEntry = [
+      'stock' => [
+        'adjustment' => 33,
+        'entry_system' => 'basic',
+      ],
+    ];
+    $this->variation->set('test_stock_level', $stubBasicEntry);
+    $this->variation->save();
+    $this->assertEquals(88, $this->checker->getTotalStockLevel($this->variation, $this->locations));
+  }
+
+  /**
+   * Whether negative values via basic entry system works. Negative values
+   * should reduce the stock level.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testStockLevelBasicEntryStockOut() {
+    $stubBasicEntry = [
+      'stock' => [
+        'adjustment' => -33,
+        'entry_system' => 'basic',
+      ],
+    ];
+    $this->variation->set('test_stock_level', $stubBasicEntry);
+    $this->variation->save();
+    $this->assertEquals(22, $this->checker->getTotalStockLevel($this->variation, $this->locations));
+  }
+
+}

--- a/src/EventSubscriber/OrderEventSubscriber.php
+++ b/src/EventSubscriber/OrderEventSubscriber.php
@@ -122,9 +122,9 @@ class OrderEventSubscriber implements EventSubscriberInterface {
    */
   public function onOrderCancel(WorkflowTransitionEvent $event) {
     $order = $event->getEntity();
-     if ($order->original && $order->original->getState()->value === 'draft') {
-       return;
-     }
+    if ($order->original && $order->original->getState()->value === 'draft') {
+      return;
+    }
     foreach ($order->getItems() as $item) {
       $entity = $item->getPurchasedEntity();
       if (!$entity) {

--- a/tests/src/Functional/OrderEventTransactionsTest.php
+++ b/tests/src/Functional/OrderEventTransactionsTest.php
@@ -223,7 +223,7 @@ class OrderEventTransactionsTest extends StockBrowserTestBase {
   }
 
   /**
-   *
+   * Whether transactions are created on order save.
    */
   public function testOrderSaveEvent() {
     // Tests initial stock level transactions set by the field values.


### PR DESCRIPTION
Rebase, to get some better diff.
https://www.drupal.org/project/commerce_stock/issues/2738807#comment-12532071

- Adds test for the stock level class.
- Fixes a small bug: Due to early bailout in setValue()
  setting a plain value wasn't possible.
- Optimization: Lazy load stockServiceManager in setValue(). 

Note: 
- The OrderEventsTest is fixed in another PR.
- The new Drupal\Tests\commerce_stock_field\Kernel\StockLevelTest passes, So it should be fine.