### PR TITLE
Adding missing unit_currency and entity_type schema fields

### DIFF
--- a/modules/field/src/Plugin/Field/FieldType/StockLevel.php
+++ b/modules/field/src/Plugin/Field/FieldType/StockLevel.php
@@ -145,10 +145,14 @@ class StockLevel extends FieldItemBase {
         $zone = '';
         // @todo Implement unit_cost?
         $unit_cost = NULL;
+        $unit_currency = NULL;
+        // $unit_cost = $values['stock']['stocked_entity']->get('price')->getValue()[0]['number'];
+        // $unit_currency = $values['stock']['stocked_entity']->get('price')->getValue()[0]['currency_code'];
+
         // @ToDo Make this hardcoded note translatable or remove it at all.
         $transaction_note = isset($values['stock']['stock_transaction_note']) ? $values['stock']['stock_transaction_note'] : 'stock level set or updated by field';
         $metadata = ['data' => ['message' => $transaction_note]];
-        $this->stockServiceManager->createTransaction($entity, $location->getId(), $zone, $transaction_qty, $unit_cost, $transaction_type, $metadata);
+        $this->stockServiceManager->createTransaction($entity, $location->getId(), $zone, $transaction_qty, $unit_cost, $unit_currency, $transaction_type, $metadata);
       }
     }
   }

--- a/modules/field/src/Plugin/Field/FieldType/StockLevel.php
+++ b/modules/field/src/Plugin/Field/FieldType/StockLevel.php
@@ -145,14 +145,14 @@ class StockLevel extends FieldItemBase {
         $zone = '';
         // @todo Implement unit_cost?
         $unit_cost = NULL;
-        $unit_currency = NULL;
+        $currency_code = NULL;
         // $unit_cost = $values['stock']['stocked_entity']->get('price')->getValue()[0]['number'];
-        // $unit_currency = $values['stock']['stocked_entity']->get('price')->getValue()[0]['currency_code'];
+        // $currency_code = $values['stock']['stocked_entity']->get('price')->getValue()[0]['currency_code'];
 
         // @ToDo Make this hardcoded note translatable or remove it at all.
         $transaction_note = isset($values['stock']['stock_transaction_note']) ? $values['stock']['stock_transaction_note'] : 'stock level set or updated by field';
         $metadata = ['data' => ['message' => $transaction_note]];
-        $this->stockServiceManager->createTransaction($entity, $location->getId(), $zone, $transaction_qty, $unit_cost, $unit_currency, $transaction_type, $metadata);
+        $this->stockServiceManager->createTransaction($entity, $location->getId(), $zone, $transaction_qty, $unit_cost, $currency_code, $transaction_type, $metadata);
       }
     }
   }

--- a/modules/local_storage/commerce_stock_local.install
+++ b/modules/local_storage/commerce_stock_local.install
@@ -98,6 +98,12 @@ function commerce_stock_local_schema() {
         'precision' => 19,
         'scale' => 6,
       ],
+      'unit_currency' => [
+        'description' => 'Unit currency',
+        'type'        => 'varchar_ascii',
+        'length'      => 28,
+        'not null'    => FALSE,
+      ],
       'transaction_time' => [
         'type' => 'int',
         'not null' => TRUE,
@@ -185,6 +191,12 @@ function commerce_stock_local_schema() {
         'type'        => 'int',
         'unsigned'    => TRUE,
         'not null'    => TRUE,
+      ],
+      'entity_type' => [
+        'description' => 'Purchasable entity type',
+        'type'        => 'varchar_ascii',
+        'length'      => EntityTypeInterface::ID_MAX_LENGTH,
+        'not null'    => FALSE,
       ],
       'qty' => [
         'description' => 'The quantity',
@@ -295,4 +307,27 @@ function commerce_stock_local_update_8001() {
   ];
   $schema = \Drupal::database()->schema();
   $schema->addField('commerce_stock_transaction', 'entity_type', $spec);
+}
+
+/**
+ * Adds 'entity_type' column to commerce_stock_location_level table.
+ */
+function commerce_stock_local_update_8002() {
+  $spec = [
+    'description' => 'Purchasable entity type',
+    'type'        => 'varchar_ascii',
+    'length'      => EntityTypeInterface::ID_MAX_LENGTH,
+    'not null'    => FALSE,
+  ];
+  $schema = \Drupal::database()->schema();
+  $schema->addField('commerce_stock_location_level', 'entity_type', $spec);
+
+  $spec1 = [
+    'description' => 'The currency for unit',
+    'type'        => 'varchar_ascii',
+    'length'      => 28,
+    'not null'    => FALSE,
+  ];
+  $schema1 = \Drupal::database()->schema();
+  $schema1->addField('commerce_stock_transaction', 'unit_currency', $spec1);
 }

--- a/modules/local_storage/commerce_stock_local.install
+++ b/modules/local_storage/commerce_stock_local.install
@@ -98,11 +98,10 @@ function commerce_stock_local_schema() {
         'precision' => 19,
         'scale' => 6,
       ],
-      'unit_currency' => [
-        'description' => 'Unit currency',
-        'type'        => 'varchar_ascii',
-        'length'      => 28,
-        'not null'    => FALSE,
+      'currency_code' => [
+        'description' => 'The currency code.',
+        'type'        => 'varchar',
+        'length'      => 3,
       ],
       'transaction_time' => [
         'type' => 'int',
@@ -323,11 +322,10 @@ function commerce_stock_local_update_8002() {
   $schema->addField('commerce_stock_location_level', 'entity_type', $spec);
 
   $spec1 = [
-    'description' => 'The currency for unit',
-    'type'        => 'varchar_ascii',
-    'length'      => 28,
-    'not null'    => FALSE,
+    'description' => 'The currency code',
+    'type'        => 'varchar',
+    'length'      => 3,
   ];
   $schema1 = \Drupal::database()->schema();
-  $schema1->addField('commerce_stock_transaction', 'unit_currency', $spec1);
+  $schema1->addField('commerce_stock_transaction', 'currency_code', $spec1);
 }

--- a/modules/local_storage/commerce_stock_local.views.inc
+++ b/modules/local_storage/commerce_stock_local.views.inc
@@ -225,6 +225,22 @@ function commerce_stock_local_views_data() {
       'id' => 'standard',
     ],
   ];
+  $data['commerce_stock_transaction']['unit_currency'] = [
+    'title' => t('Unit currency'),
+    'help' => t('The currency of a single unit.'),
+    'field' => [
+      'id' => 'standard',
+    ],
+    'filter' => [
+      'id' => 'string',
+    ],
+    'argument' => [
+      'id' => 'string',
+    ],
+    'sort' => [
+      'id' => 'standard',
+    ],
+  ];
   $data['commerce_stock_transaction']['transaction_time'] = [
     'title' => t('Time'),
     'help' => t('The date & time of the transaction.'),

--- a/modules/local_storage/commerce_stock_local.views.inc
+++ b/modules/local_storage/commerce_stock_local.views.inc
@@ -225,9 +225,9 @@ function commerce_stock_local_views_data() {
       'id' => 'standard',
     ],
   ];
-  $data['commerce_stock_transaction']['unit_currency'] = [
-    'title' => t('Unit currency'),
-    'help' => t('The currency of a single unit.'),
+  $data['commerce_stock_transaction']['currency_code'] = [
+    'title' => t('Currency code'),
+    'help' => t('The currency code of a single unit.'),
     'field' => [
       'id' => 'standard',
     ],

--- a/modules/local_storage/src/LocalStockUpdater.php
+++ b/modules/local_storage/src/LocalStockUpdater.php
@@ -58,7 +58,7 @@ class LocalStockUpdater implements StockUpdateInterface {
   /**
    * {@inheritdoc}
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, array $metadata) {
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata) {
     // Get optional fields.
     $related_tid = isset($metadata['related_tid']) ? $metadata['related_tid'] : NULL;
     $related_oid = isset($metadata['related_oid']) ? $metadata['related_oid'] : NULL;
@@ -73,6 +73,7 @@ class LocalStockUpdater implements StockUpdateInterface {
       'location_id' => $location_id,
       'location_zone' => $zone,
       'unit_cost' => $unit_cost,
+      'unit_currency' => $unit_currency,
       'transaction_time' => time(),
       'transaction_type_id' => $transaction_type_id,
       'related_tid' => $related_tid,
@@ -80,6 +81,7 @@ class LocalStockUpdater implements StockUpdateInterface {
       'related_uid' => $related_uid,
       'data' => serialize($data),
     ];
+
     $insert = $this->database->insert('commerce_stock_transaction')
       ->fields(array_keys($field_values))
       ->values(array_values($field_values))->execute();
@@ -126,6 +128,7 @@ class LocalStockUpdater implements StockUpdateInterface {
       ->fields('ll')
       ->condition('location_id', $location_id)
       ->condition('entity_id', $entity->id())
+      ->condition('entity_type', $entity->getEntityTypeId())
       ->execute()->fetch();
     if ($existing) {
       $this->database->update('commerce_stock_location_level')
@@ -139,8 +142,8 @@ class LocalStockUpdater implements StockUpdateInterface {
     }
     else {
       $this->database->insert('commerce_stock_location_level')
-        ->fields(['location_id', 'entity_id', 'qty', 'last_transaction_id'])
-        ->values([$location_id, $entity->id(), $qty, $last_txn])
+        ->fields(['location_id', 'entity_id', 'entity_type', 'qty', 'last_transaction_id'])
+        ->values([$location_id, $entity->id(), $entity->getEntityTypeId(), $qty, $last_txn])
         ->execute();
     }
   }

--- a/modules/local_storage/src/LocalStockUpdater.php
+++ b/modules/local_storage/src/LocalStockUpdater.php
@@ -58,7 +58,7 @@ class LocalStockUpdater implements StockUpdateInterface {
   /**
    * {@inheritdoc}
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata) {
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, array $metadata) {
     // Get optional fields.
     $related_tid = isset($metadata['related_tid']) ? $metadata['related_tid'] : NULL;
     $related_oid = isset($metadata['related_oid']) ? $metadata['related_oid'] : NULL;
@@ -73,7 +73,7 @@ class LocalStockUpdater implements StockUpdateInterface {
       'location_id' => $location_id,
       'location_zone' => $zone,
       'unit_cost' => $unit_cost,
-      'unit_currency' => $unit_currency,
+      'currency_code' => $currency_code,
       'transaction_time' => time(),
       'transaction_type_id' => $transaction_type_id,
       'related_tid' => $related_tid,

--- a/modules/ui/src/Form/StockTransactions2.php
+++ b/modules/ui/src/Form/StockTransactions2.php
@@ -215,22 +215,22 @@ class StockTransactions2 extends FormBase {
     $product_variation = $this->productVariationStorage->load($product_variation_id);
 
     if ($transaction_type == 'receiveStock') {
-      $this->stockServiceManager->receiveStock($product_variation, $source_location, $source_zone, $qty, NULL, $unit_currency = NULL, $transaction_note);
+      $this->stockServiceManager->receiveStock($product_variation, $source_location, $source_zone, $qty, NULL, $currency_code = NULL, $transaction_note);
     }
     elseif ($transaction_type == 'sellStock') {
       $order_id = $form_state->getValue('order');;
       $user_id = $form_state->getValue('user');;
-      $this->stockServiceManager->sellStock($product_variation, $source_location, $source_zone, $qty, NULL, $unit_currency = NULL, $order_id, $user_id, $transaction_note);
+      $this->stockServiceManager->sellStock($product_variation, $source_location, $source_zone, $qty, NULL, $currency_code = NULL, $order_id, $user_id, $transaction_note);
     }
     elseif ($transaction_type == 'returnStock') {
       $order_id = $form_state->getValue('order');;
       $user_id = $form_state->getValue('user');;
-      $this->stockServiceManager->returnStock($product_variation, $source_location, $source_zone, $qty, NULL, $unit_currency = NULL, $order_id, $user_id, $transaction_note);
+      $this->stockServiceManager->returnStock($product_variation, $source_location, $source_zone, $qty, NULL, $currency_code = NULL, $order_id, $user_id, $transaction_note);
     }
     elseif ($transaction_type == 'moveStock') {
       $target_location = $form_state->getValue('target_location');
       $target_zone = $form_state->getValue('target_zone');
-      $this->stockServiceManager->moveStock($product_variation, $source_location, $target_location, $source_zone, $target_zone, $qty, NULL, $unit_currency = NULL, $transaction_note);
+      $this->stockServiceManager->moveStock($product_variation, $source_location, $target_location, $source_zone, $target_zone, $qty, NULL, $currency_code = NULL, $transaction_note);
     }
   }
 

--- a/modules/ui/src/Form/StockTransactions2.php
+++ b/modules/ui/src/Form/StockTransactions2.php
@@ -215,22 +215,22 @@ class StockTransactions2 extends FormBase {
     $product_variation = $this->productVariationStorage->load($product_variation_id);
 
     if ($transaction_type == 'receiveStock') {
-      $this->stockServiceManager->receiveStock($product_variation, $source_location, $source_zone, $qty, NULL, $transaction_note);
+      $this->stockServiceManager->receiveStock($product_variation, $source_location, $source_zone, $qty, NULL, $unit_currency = NULL, $transaction_note);
     }
     elseif ($transaction_type == 'sellStock') {
       $order_id = $form_state->getValue('order');;
       $user_id = $form_state->getValue('user');;
-      $this->stockServiceManager->sellStock($product_variation, $source_location, $source_zone, $qty, NULL, $order_id, $user_id, $transaction_note);
+      $this->stockServiceManager->sellStock($product_variation, $source_location, $source_zone, $qty, NULL, $unit_currency = NULL, $order_id, $user_id, $transaction_note);
     }
     elseif ($transaction_type == 'returnStock') {
       $order_id = $form_state->getValue('order');;
       $user_id = $form_state->getValue('user');;
-      $this->stockServiceManager->returnStock($product_variation, $source_location, $source_zone, $qty, NULL, $order_id, $user_id, $transaction_note);
+      $this->stockServiceManager->returnStock($product_variation, $source_location, $source_zone, $qty, NULL, $unit_currency = NULL, $order_id, $user_id, $transaction_note);
     }
     elseif ($transaction_type == 'moveStock') {
       $target_location = $form_state->getValue('target_location');
       $target_zone = $form_state->getValue('target_zone');
-      $this->stockServiceManager->moveStock($product_variation, $source_location, $target_location, $source_zone, $target_zone, $qty, NULL, $transaction_note);
+      $this->stockServiceManager->moveStock($product_variation, $source_location, $target_location, $source_zone, $target_zone, $qty, NULL, $unit_currency = NULL, $transaction_note);
     }
   }
 

--- a/src/AlwaysInStock.php
+++ b/src/AlwaysInStock.php
@@ -12,7 +12,7 @@ class AlwaysInStock implements StockCheckInterface, StockUpdateInterface {
   /**
    * {@inheritdoc}
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, array $metadata) {
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata) {
     // Do nothing and return a NULL value as its N/A.
     return NULL;
   }

--- a/src/AlwaysInStock.php
+++ b/src/AlwaysInStock.php
@@ -12,7 +12,7 @@ class AlwaysInStock implements StockCheckInterface, StockUpdateInterface {
   /**
    * {@inheritdoc}
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata) {
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, array $metadata) {
     // Do nothing and return a NULL value as its N/A.
     return NULL;
   }

--- a/src/Plugin/StockEvents/CoreStockEvents.php
+++ b/src/Plugin/StockEvents/CoreStockEvents.php
@@ -53,7 +53,7 @@ class CoreStockEvents extends PluginBase implements StockEventsInterface {
       ->getService($entity);
     // Use the stock updater to create the transaction.
     $transaction_id = $stockService->getStockUpdater()
-      ->createTransaction($entity, $location->getId(), '', $quantity, NULL, $transaction_type, $metadata);
+       ->createTransaction($entity, $location->getId(), '', $quantity, NULL, $unit_currency = NULL, $transaction_type, $metadata);
     // Return the transaction ID.
     return $transaction_id;
   }

--- a/src/Plugin/StockEvents/CoreStockEvents.php
+++ b/src/Plugin/StockEvents/CoreStockEvents.php
@@ -53,7 +53,7 @@ class CoreStockEvents extends PluginBase implements StockEventsInterface {
       ->getService($entity);
     // Use the stock updater to create the transaction.
     $transaction_id = $stockService->getStockUpdater()
-       ->createTransaction($entity, $location->getId(), '', $quantity, NULL, $unit_currency = NULL, $transaction_type, $metadata);
+      ->createTransaction($entity, $location->getId(), '', $quantity, NULL, $currency_code = NULL, $transaction_type, $metadata);
     // Return the transaction ID.
     return $transaction_id;
   }

--- a/src/StockServiceManager.php
+++ b/src/StockServiceManager.php
@@ -166,15 +166,15 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
   /**
    * {@inheritdoc}
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata = []) {
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, array $metadata = []) {
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $message = NULL) {
+  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $message = NULL) {
     $transaction_type_id = StockTransactionsInterface::NEW_STOCK;
     if (is_null($message)) {
       $metadata = [];
@@ -189,13 +189,13 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     // Make sure quantity is positive.
     $quantity = abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL) {
+  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $order_id, $user_id, $message = NULL) {
     $transaction_type_id = StockTransactionsInterface::STOCK_SALE;
     $metadata = [
       'related_oid' => $order_id,
@@ -207,13 +207,13 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     // Make sure quantity is positive.
     $quantity = -1 * abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $unit_currency, $message = NULL) {
+  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $currency_code, $message = NULL) {
     if (is_null($message)) {
       $metadata = [];
     }
@@ -228,16 +228,16 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     $quantity_from = -1 * abs($quantity);
     $quantity_to = abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $tid = $stock_updater->createTransaction($entity, $from_location_id, $from_zone, $quantity_from, $unit_cost, $unit_currency, StockTransactionsInterface::MOVEMENT_FROM, $metadata);
+    $tid = $stock_updater->createTransaction($entity, $from_location_id, $from_zone, $quantity_from, $unit_cost, $currency_code, StockTransactionsInterface::MOVEMENT_FROM, $metadata);
     // The second transaction will point to the first one.
     $metadata['related_tid'] = $tid;
-    $stock_updater->createTransaction($entity, $to_location_id, $to_zone, $quantity_to, $unit_cost, $unit_currency, StockTransactionsInterface::MOVEMENT_TO, $metadata);
+    $stock_updater->createTransaction($entity, $to_location_id, $to_zone, $quantity_to, $unit_cost, $currency_code, StockTransactionsInterface::MOVEMENT_TO, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL) {
+  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $order_id, $user_id, $message = NULL) {
     $transaction_type_id = StockTransactionsInterface::STOCK_RETURN;
     $metadata = [
       'related_oid' => $order_id,
@@ -249,7 +249,7 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     // Make sure quantity is positive.
     $quantity = abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, $metadata);
   }
 
   /**

--- a/src/StockServiceManager.php
+++ b/src/StockServiceManager.php
@@ -166,15 +166,15 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
   /**
    * {@inheritdoc}
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, array $metadata = []) {
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata = []) {
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $message = NULL) {
+  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $message = NULL) {
     $transaction_type_id = StockTransactionsInterface::NEW_STOCK;
     if (is_null($message)) {
       $metadata = [];
@@ -189,13 +189,13 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     // Make sure quantity is positive.
     $quantity = abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $order_id, $user_id, $message = NULL) {
+  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL) {
     $transaction_type_id = StockTransactionsInterface::STOCK_SALE;
     $metadata = [
       'related_oid' => $order_id,
@@ -207,13 +207,13 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     // Make sure quantity is positive.
     $quantity = -1 * abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $message = NULL) {
+  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $unit_currency, $message = NULL) {
     if (is_null($message)) {
       $metadata = [];
     }
@@ -228,16 +228,16 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     $quantity_from = -1 * abs($quantity);
     $quantity_to = abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $tid = $stock_updater->createTransaction($entity, $from_location_id, $from_zone, $quantity_from, $unit_cost, StockTransactionsInterface::MOVEMENT_FROM, $metadata);
+    $tid = $stock_updater->createTransaction($entity, $from_location_id, $from_zone, $quantity_from, $unit_cost, $unit_currency, StockTransactionsInterface::MOVEMENT_FROM, $metadata);
     // The second transaction will point to the first one.
     $metadata['related_tid'] = $tid;
-    $stock_updater->createTransaction($entity, $to_location_id, $to_zone, $quantity_to, $unit_cost, StockTransactionsInterface::MOVEMENT_TO, $metadata);
+    $stock_updater->createTransaction($entity, $to_location_id, $to_zone, $quantity_to, $unit_cost, $unit_currency, StockTransactionsInterface::MOVEMENT_TO, $metadata);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $order_id, $user_id, $message = NULL) {
+  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL) {
     $transaction_type_id = StockTransactionsInterface::STOCK_RETURN;
     $metadata = [
       'related_oid' => $order_id,
@@ -249,7 +249,7 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
     // Make sure quantity is positive.
     $quantity = abs($quantity);
     $stock_updater = $this->getService($entity)->getStockUpdater();
-    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, $metadata);
+    $stock_updater->createTransaction($entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, $metadata);
   }
 
   /**

--- a/src/StockTransactionsInterface.php
+++ b/src/StockTransactionsInterface.php
@@ -76,14 +76,14 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
-   * @param string $unit_currency
-   *   The unit currency.
+   * @param string $currency_code
+   *   The currency code.
    * @param int $transaction_type_id
    *   Transaction type ID.
    * @param array $metadata
    *   A metadata array.
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata = []);
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, array $metadata = []);
 
   /**
    * Receive stock.
@@ -98,12 +98,12 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
-   * @param string $unit_currency
-   *   The unit currency.
+   * @param string $currency_code
+   *   The currency code.
    * @param string $message
    *   The message.
    */
-  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $message = NULL);
+  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $message = NULL);
 
   /**
    * Sell stock.
@@ -118,8 +118,8 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
-   * @param string $unit_currency
-   *   The unit currency.
+   * @param string $currency_code
+   *   The currency code.
    * @param int $order_id
    *   The order ID.
    * @param int $user_id
@@ -127,7 +127,7 @@ interface StockTransactionsInterface {
    * @param string $message
    *   The message.
    */
-  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL);
+  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $order_id, $user_id, $message = NULL);
 
   /**
    * Move stock.
@@ -146,12 +146,12 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
-   * @param string $unit_currency
-   *   The unit currency.
+   * @param string $currency_code
+   *   The currency code.
    * @param string $message
    *   The message.
    */
-  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $unit_currency, $message = NULL);
+  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $currency_code, $message = NULL);
 
   /**
    * Stock returns.
@@ -166,8 +166,8 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
-   * @param string $unit_currency
-   *   The unit currency.
+   * @param string $currency_code
+   *   The currency code.
    * @param int $order_id
    *   The order ID.
    * @param int $user_id
@@ -175,6 +175,6 @@ interface StockTransactionsInterface {
    * @param string $message
    *   The message.
    */
-  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL);
+  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $order_id, $user_id, $message = NULL);
 
 }

--- a/src/StockTransactionsInterface.php
+++ b/src/StockTransactionsInterface.php
@@ -76,12 +76,14 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
+   * @param string $unit_currency
+   *   The unit currency.
    * @param int $transaction_type_id
    *   Transaction type ID.
    * @param array $metadata
    *   A metadata array.
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, array $metadata = []);
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata = []);
 
   /**
    * Receive stock.
@@ -96,10 +98,12 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
+   * @param string $unit_currency
+   *   The unit currency.
    * @param string $message
    *   The message.
    */
-  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $message = NULL);
+  public function receiveStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $message = NULL);
 
   /**
    * Sell stock.
@@ -114,6 +118,8 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
+   * @param string $unit_currency
+   *   The unit currency.
    * @param int $order_id
    *   The order ID.
    * @param int $user_id
@@ -121,7 +127,7 @@ interface StockTransactionsInterface {
    * @param string $message
    *   The message.
    */
-  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $order_id, $user_id, $message = NULL);
+  public function sellStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL);
 
   /**
    * Move stock.
@@ -140,10 +146,12 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
+   * @param string $unit_currency
+   *   The unit currency.
    * @param string $message
    *   The message.
    */
-  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $message = NULL);
+  public function moveStock(PurchasableEntityInterface $entity, $from_location_id, $to_location_id, $from_zone, $to_zone, $quantity, $unit_cost, $unit_currency, $message = NULL);
 
   /**
    * Stock returns.
@@ -158,6 +166,8 @@ interface StockTransactionsInterface {
    *   The quantity.
    * @param float $unit_cost
    *   The unit cost.
+   * @param string $unit_currency
+   *   The unit currency.
    * @param int $order_id
    *   The order ID.
    * @param int $user_id
@@ -165,6 +175,6 @@ interface StockTransactionsInterface {
    * @param string $message
    *   The message.
    */
-  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $order_id, $user_id, $message = NULL);
+  public function returnStock(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $order_id, $user_id, $message = NULL);
 
 }

--- a/src/StockUpdateInterface.php
+++ b/src/StockUpdateInterface.php
@@ -22,6 +22,8 @@ interface StockUpdateInterface {
    *   Tbe quantity.
    * @param float $unit_cost
    *   The unit cost.
+   * @param string $unit_currency
+   *   The unit currency.
    * @param int $transaction_type_id
    *   The transaction type ID.
    * @param array $metadata
@@ -34,6 +36,6 @@ interface StockUpdateInterface {
    * @return int
    *   Return the ID of the transaction.
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $transaction_type_id, array $metadata);
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata);
 
 }

--- a/src/StockUpdateInterface.php
+++ b/src/StockUpdateInterface.php
@@ -22,8 +22,8 @@ interface StockUpdateInterface {
    *   Tbe quantity.
    * @param float $unit_cost
    *   The unit cost.
-   * @param string $unit_currency
-   *   The unit currency.
+   * @param string $currency_code
+   *   The currency code.
    * @param int $transaction_type_id
    *   The transaction type ID.
    * @param array $metadata
@@ -36,6 +36,6 @@ interface StockUpdateInterface {
    * @return int
    *   Return the ID of the transaction.
    */
-  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $unit_currency, $transaction_type_id, array $metadata);
+  public function createTransaction(PurchasableEntityInterface $entity, $location_id, $zone, $quantity, $unit_cost, $currency_code, $transaction_type_id, array $metadata);
 
 }


### PR DESCRIPTION
Hello,

We added the different fields to the schema.

For the commerce_stock_transaction we only add the field unit_currency, but like unit_cost is null.

We commented the line to populate it with real value into the modules/field/src/Plugin/Field/FieldType/StockLevel.php file.

For the commerce_stock_location_level table, we add the entity_type field too and we populate it.

But we would like to know how to test when the cron add data to this table.

Sincerely,

itss-official team