### PR TITLE
clean up logic and add proper dependency injection

### DIFF
--- a/commerce_stock.services.yml
+++ b/commerce_stock.services.yml
@@ -9,7 +9,7 @@ services:
     class: Drupal\commerce_stock\StockServiceManager
     tags:
       - { name: service_collector, tag: commerce_stock.stock_service, call: addService }
-    arguments: [ '@config.factory' ]
+    arguments: [ '@config.factory', '@commerce_store.current_store', '@current_user' ]
 
   commerce_stock.always_in_stock_service:
     class: Drupal\commerce_stock\AlwaysInStockService

--- a/src/StockServiceManager.php
+++ b/src/StockServiceManager.php
@@ -122,7 +122,7 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
       $this->getContextDetails($entity);
     }
     catch (\Exception $e) {
-      //@todo log the exception?
+      // @todo log the exception?
       return FALSE;
     }
     return TRUE;
@@ -137,8 +137,8 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
    * @throws \Exception
    *   When the entity can't be purchased from the current store.
    *
-   * @see \Drupal\commerce_cart\Form\AddToCartForm::selectStore() for the
-   * original logic.
+   * @see \Drupal\commerce_cart\Form\AddToCartForm::selectStore()
+   *   Original logic comes from this function.
    *
    * @return \Drupal\commerce\Context
    *   The Stock service context.
@@ -166,6 +166,7 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
 
   /**
    * {@inheritdoc}
+   *
    * @todo code sniffer error here, can't have optional params first.
    */
   public function getTransactionLocation(Context $context = NULL, PurchasableEntityInterface $entity, $quantity) {

--- a/src/StockServiceManager.php
+++ b/src/StockServiceManager.php
@@ -122,7 +122,6 @@ class StockServiceManager implements StockServiceManagerInterface, StockTransact
       $this->getContextDetails($entity);
     }
     catch (\Exception $e) {
-      //@todo log the exception?
       return FALSE;
     }
     return TRUE;

--- a/src/StockTransactionsInterface.php
+++ b/src/StockTransactionsInterface.php
@@ -26,6 +26,8 @@ interface StockTransactionsInterface {
    * @param \Drupal\commerce\PurchasableEntityInterface $entity
    *   The purchasable entity (most likely a product variation entity).
    *
+   * @throws \Exception
+   *
    * @return \Drupal\commerce\Context
    *   The context containing the customer & store.
    */
@@ -40,14 +42,14 @@ interface StockTransactionsInterface {
    *   The purchasable entity (most likely a product variation entity).
    *
    * @return bool
-   *   True if valid, False if not..
+   *   TRUE if valid, FALSE if not.
    */
   public function isValidContext(PurchasableEntityInterface $entity);
 
   /**
    * Get the location to be used for automatic stock allocation.
    *
-   * This is normaly done by calling the stock service
+   * This is normally done by calling the stock service
    * StockServiceConfigInterface getTransactionLocation() and is provided as a
    * util function.
    *

--- a/tests/src/Kernel/StockServiceManagerTest.php
+++ b/tests/src/Kernel/StockServiceManagerTest.php
@@ -23,7 +23,9 @@ class StockServiceManagerTest extends CommerceStockKernelTestBase {
   public function setUp() {
     parent::setUp();
     $configFactory = $this->container->get('config.factory');
-    $this->stockServiceManager = new StockServiceManager($configFactory);
+    $currentStore = $this->container->get('commerce_store.current_store');
+    $this->user = $this->createUser();
+    $this->stockServiceManager = new StockServiceManager($configFactory, $currentStore, $this->user);
   }
 
   /**


### PR DESCRIPTION
from https://www.drupal.org/project/commerce_stock/issues/3009902

Refactore StockServiceManager::getContextDetails
> StockServiceManager::getContextDetails is a little confusing.

> 1) Throw in case of malformed entity

> In case we get no stores from Entity we should throw an exception, like commerce AddToCart::selectStore

> 2) Get rid of $found parameter. Its useless.

> I guess it was there for isValidContext, but it makes the code hard to understand. If we let getContextDetails throw in case of error(s), we can rewrite isValidContext with a try/catch.