### PR TITLE
Issue #2931754 olafkarsten: Split the SimpleStockLevelWidget in three…

### DIFF
--- a/commerce_stock.links.menu.yml
+++ b/commerce_stock.links.menu.yml
@@ -1,6 +1,6 @@
 commerce_stock.configuration:
   title: 'Stock'
-  route_name: 'commerce_stock.configuration'
+  route_name: commerce_stock.configuration
   parent: 'commerce.configuration'
   weight: -5
 

--- a/modules/field/config/schema/commerce_stock_field.schema.yml
+++ b/modules/field/config/schema/commerce_stock_field.schema.yml
@@ -19,3 +19,31 @@ field.widget.settings.commerce_stock_level_simple:
     context_fallback:
       type: boolean
       label: 'Whether the context fallback should be uses.'
+
+field.widget.settings.commerce_stock_level_absolute:
+  type: mapping
+  label: 'Stock level field display format settings'
+  mapping:
+    step:
+      type: string
+      label: 'Step'
+    custom_transaction_note:
+      type: boolean
+      label: 'Whether a transaction note should be captured by the widget'
+    default_transaction_note:
+      type: text
+      label: 'The default transaction note'
+
+field.widget.settings.commerce_stock_level_simple_transaction:
+  type: mapping
+  label: 'Stock level field display format settings'
+  mapping:
+    step:
+      type: string
+      label: 'Step'
+    custom_transaction_note:
+      type: boolean
+      label: 'Whether a transaction note should be captured by the widget'
+    default_transaction_note:
+      type: text
+      label: 'The default transaction note'

--- a/modules/field/src/Plugin/Field/FieldWidget/AbsoluteStockLevelWidget.php
+++ b/modules/field/src/Plugin/Field/FieldWidget/AbsoluteStockLevelWidget.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\commerce_stock_field\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'absolute_commerce_stock_level' widget.
+ *
+ * @FieldWidget(
+ *   id = "commerce_stock_level_absolute",
+ *   module = "commerce_stock_field",
+ *   label = @Translation("Absolute stock level"),
+ *   description = @Translation("Sets the absolute stock level. You will loose
+ *   all the glamour of transaction based stock handling. We recommend using
+ *   the simple stock transaction widget instead. Learn more in the
+ *   documentation."), field_types = {
+ *     "commerce_stock_level"
+ *   }
+ * )
+ */
+class AbsoluteStockLevelWidget extends StockLevelWidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(
+    FieldItemListInterface $items,
+    $delta,
+    array $element,
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $field = $items->first();
+    $level = $field->available_stock;
+    $element['stock_level'] = array_merge(
+      $element['adjustment'],
+      [
+        '#title' => $this->t('Absolute stock level settings'),
+        '#description' => $this->t('Sets the stock level. Current stock level: @stock_level. Note: Under the hood we create a transaction. Setting the absolute stock level may end in unexpected results. Learn more about transactional inventory management in the docs.', ['@stock_level' => $level]),
+        '#min' => 0,
+        // We don't use zero as default, because its a valid value and would reset
+        // the stock level to 0.
+        '#default_value' => NULL,
+
+      ]);
+    unset($element['adjustment']);
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    if (isset($values[0]['stock_level'])) {
+      if (empty($values[0]['stock_level']) && $values[0]['stock_level'] !== "0") {
+        $values[0]['adjustment'] = NULL;
+        return $values;
+      }
+      $new_level = $values[0]['stock_level'];
+      $current_level = $this->stockServiceManager->getStockLevel($values[0]['stocked_entity']);
+      $values[0]['adjustment'] = $new_level - $current_level;
+      return $values;
+    }
+    return $values;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getHelpText() {
+    return $this->t("Set the absolute stock level. We don't recommend using this widget. Read the docs to learn why.");
+  }
+
+}

--- a/modules/field/src/Plugin/Field/FieldWidget/SimpleStockTransactionWidget.php
+++ b/modules/field/src/Plugin/Field/FieldWidget/SimpleStockTransactionWidget.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\commerce_stock_field\Plugin\Field\FieldWidget;
+
+/**
+ * Plugin implementation of the 'commerce_stock_level_simple_transaction' widget.
+ *
+ * @FieldWidget(
+ *   id = "commerce_stock_level_simple_transaction",
+ *   label = @Translation("Simple stock transaction"),
+ *   description = @Translation("Do simple stock transactions (add, remove) on
+ *   the edit form of a purchasable entity."),
+ *   field_types = {
+ *     "commerce_stock_level"
+ *   }
+ * )
+ */
+class SimpleStockTransactionWidget extends StockLevelWidgetBase {
+
+  /**
+   * @inheritdoc
+   */
+  protected function getHelpText() {
+    return $this->t('Simple stock adjustments right on the product edit form. We recommend using this widget. Learn in the docs why.');
+  }
+
+}

--- a/modules/field/src/Plugin/Field/FieldWidget/StockLevelWidgetBase.php
+++ b/modules/field/src/Plugin/Field/FieldWidget/StockLevelWidgetBase.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Drupal\commerce_stock_field\Plugin\Field\FieldWidget;
+
+use Drupal\commerce\PurchasableEntityInterface;
+use Drupal\commerce_stock\StockServiceManager;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the base structure for commerce stock level widgets.
+ */
+abstract class StockLevelWidgetBase extends WidgetBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The Stock Service Manager.
+   *
+   * @var \Drupal\commerce_stock\StockServiceManager
+   */
+  protected $stockServiceManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    array $third_party_settings,
+    StockServiceManager $stock_service_manager
+  ) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
+    $this->stockServiceManager = $stock_service_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['third_party_settings'],
+      $container->get('commerce_stock.service_manager'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'custom_transaction_note' => FALSE,
+      'default_transaction_note' => t('Transaction issued by stock level field.'),
+      'step' => '1',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    if ($this->getSetting('step') == 1) {
+      $summary[] = $this->t('Decimal stock levels not allowed');
+    }
+    else {
+      $summary[] = $this->t('Decimal stock levels allowed');
+      $summary[] = $this->t('Step: @step', ['@step' => $this->getSetting('step')]);
+    }
+
+    $summary[] = $this->t('Default transaction note: @transaction_note', ['@transaction_note' => $this->getSetting('default_transaction_note')]);
+    $summary[] = $this->t('Custom transaction note @allowed allowed.', ['@allowed' => $this->getSetting('custom_transaction_note') ? '' : 'not']);
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $field_name = $this->fieldDefinition->getName();
+    $element = [];
+    if ($this->hasHelpText()) {
+      $element = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $this->getHelpText(),
+      ];
+    }
+
+    $element['default_transaction_note'] = [
+      '#title' => $this->t('Default transaction note'),
+      '#description' => $this->t('Use this as default transaction note.'),
+      '#type' => 'textfield',
+      '#default_value' => $this->getSetting('default_transaction_note'),
+      '#size' => 50,
+      '#maxlength' => 255,
+    ];
+    $element['custom_transaction_note'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow custom note per transaction.'),
+      '#default_value' => $this->getSetting('custom_transaction_note'),
+    ];
+    // Shameless borrowed from commerce quantity field.
+    $step = $this->getSetting('step');
+    $element['#element_validate'][] = [
+      get_class($this),
+      'validateSettingsForm',
+    ];
+    $element['allow_decimal'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow decimal quantities'),
+      '#default_value' => $step != '1',
+    ];
+    $element['step'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Step'),
+      '#description' => $this->t('Only stock levels that are multiples of the selected step will be allowed. Maximum precision is 2 (0.01).'),
+      '#default_value' => $step != '1' ? $step : '0.1',
+      '#options' => [
+        '0.1' => '0.1',
+        '0.01' => '0.01',
+        '0.25' => '0.25',
+        '0.5' => '0.5',
+        '0.05' => '0.05',
+      ],
+      '#states' => [
+        'visible' => [
+          ':input[name="fields[' . $field_name . '][settings_edit_form][settings][allow_decimal]"]' => ['checked' => TRUE],
+        ],
+      ],
+      '#required' => TRUE,
+    ];
+    return $element;
+  }
+
+  /**
+   * Validates the settings form.
+   *
+   * @param array $element
+   *   The settings form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function validateSettingsForm(
+    array $element,
+    FormStateInterface $form_state
+  ) {
+    $value = $form_state->getValue($element['#parents']);
+    if (empty($value['allow_decimal'])) {
+      $value['step'] = '1';
+    }
+    unset($value['allow_decimal']);
+    $form_state->setValue($element['#parents'], $value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(
+    FieldItemListInterface $items,
+    $delta,
+    array $element,
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+    $field = $items->first();
+    $entity = $items->getEntity();
+
+    // @ToDo Use ::isApplicable instead.
+    if (!($entity instanceof PurchasableEntityInterface)) {
+      // No stock if this is not a purchasable entity.
+      return [];
+    }
+    // @ToDo Use ::isApplicable instead.
+    /** @var \Drupal\commerce_stock\StockServiceInterface $stock_service */
+    $stock_service = $this->stockServiceManager->getService($entity);
+    // @todo - service should be able can determine if it needs an interface.
+    if ($stock_service->getId() === 'always_in_stock') {
+      // Return an empty array if service is not supported.
+      return [];
+    }
+    // @ToDo Consider how this may change
+    // @see https://www.drupal.org/project/commerce_stock/issues/2949569
+    if ($entity->isNew()) {
+      // We can not work with entities before they are fully created.
+      return [];
+    }
+    // If not a valid context.
+    if (!$this->stockServiceManager->isValidContext($entity)) {
+      return [];
+    }
+
+    // Get the available stock level.
+    $level = $field->available_stock;
+
+    if (empty($entity->id())) {
+      // We don't have a product ID yet.
+      $element['#description'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'div',
+        '#value' => $this->t('In order to set the stock level you need to save the product first!'),
+      ];
+      $element['#disabled'] = TRUE;
+    }
+    else {
+      $element['#type'] = 'fieldgroup';
+      $element['#attributes'] = ['class' => ['stock-level-field']];
+
+      $element['stocked_entity'] = [
+        '#type' => 'value',
+        '#value' => $entity,
+      ];
+      $element['adjustment'] = [
+        '#title' => $this->t('Stock level adjustment'),
+        '#description' => $this->t('A positive number will add stock, a negative number will remove stock. Current stock level: @stock_level', ['@stock_level' => $level]),
+        '#type' => 'number',
+        '#step' => $this->getSetting('step'),
+        '#default_value' => 0,
+        '#size' => 7,
+      ];
+      $custom_note_allowed = $this->getSetting('custom_transaction_note');
+      $element['stock_transaction_note'] = [
+        '#title' => $this->t('Transaction note'),
+        '#description' => $custom_note_allowed ? $this->t('Add a note to this transaction.') : $this->t('Default note for transactions. Configurable in the field widget settings.'),
+        '#type' => 'textfield',
+        '#default_value' => $this->getSetting('default_transaction_note'),
+        '#size' => 50,
+        '#maxlength' => 255,
+        '#disabled' => !$custom_note_allowed,
+      ];
+
+    }
+
+    return $element;
+  }
+
+  /**
+   * Provides the help text to explain the widgets use case. Used in settings
+   * form.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup|null
+   *   The help text or NULL.
+   */
+  abstract protected function getHelpText();
+
+  /**
+   * Whether a help text is available.
+   *
+   * @return bool
+   *   TRUE if a help text is availabel, FALSE otherwise.
+   */
+  private function hasHelpText() {
+    return !empty($this->getHelpText());
+  }
+
+}

--- a/modules/field/src/Plugin/Field/FieldWidget/TransactionFormLinkWidget.php
+++ b/modules/field/src/Plugin/Field/FieldWidget/TransactionFormLinkWidget.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\commerce_stock_field\Plugin\Field\FieldWidget;
+
+use Drupal\commerce\PurchasableEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+
+/**
+ * Plugin implementation of the 'commerce_stock_level_transaction_form_link' widget.
+ *
+ * @FieldWidget(
+ *   id = "commerce_stock_level_transaction_form_link",
+ *   module = "commerce_stock_field",
+ *   label = @Translation("Link to stock transaction form"),
+ *   description = @Translation("Provides a link to a transaction form, for more complex transactions."),
+ *   field_types = {
+ *     "commerce_stock_level"
+ *   }
+ * )
+ */
+class TransactionFormLinkWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $summary[] = $this->t('Provides a link to stock transaction form.');
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(
+    FieldItemListInterface $items,
+    $delta,
+    array $element,
+    array &$form,
+    FormStateInterface $form_state
+  ) {
+
+    $field = $items->first();
+    $entity = $items->getEntity();
+
+    // @ToDo Use ::isApplicable instead.
+    if (!($entity instanceof PurchasableEntityInterface)) {
+      // No stock if this is not a purchasable entity.
+      return [];
+    }
+    // @ToDo Consider how this may change
+    // @see https://www.drupal.org/project/commerce_stock/issues/2949569
+    if ($entity->isNew()) {
+      // We can not work with entities before they are fully created.
+      return [];
+    }
+    // Get the available stock level.
+    $level = $field->available_stock;
+    $link = Link::createFromRoute(
+      $this->t('transaction form'),
+      'commerce_stock_ui.stock_transactions2',
+      ['commerce_product_v_id' => $entity->id()]
+    )->toString();
+    $element['stock_level'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'div',
+      '#value' => $this->t('Current stock level: @stock_level', ['@stock_level' => $level]),
+    ];
+    $element['stock_transactions_form_link'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'div',
+      '#value' => $this->t('Please use the @transaction to create any stock transactions.', ['@transaction' => $link]),
+    ];
+    return $element;
+  }
+
+}

--- a/modules/field/tests/src/Functional/StockLevelFieldTestBase.php
+++ b/modules/field/tests/src/Functional/StockLevelFieldTestBase.php
@@ -8,7 +8,7 @@ use Drupal\Tests\commerce_stock\Functional\StockBrowserTestBase;
 use Drupal\Tests\commerce_stock\Kernel\StockLevelFieldCreationTrait;
 
 /**
- * Provides base class for stock level field tests.
+ * Provides a base class for stock level fields functional tests.
  */
 abstract class StockLevelFieldTestBase extends StockBrowserTestBase {
 
@@ -64,7 +64,7 @@ abstract class StockLevelFieldTestBase extends StockBrowserTestBase {
       'step' => 1,
       'transaction_note' => FALSE,
     ];
-    $this->createStockLevelField($entity_type, $bundle, 'commerce_stock_level_simple', [], [], $widget_settings);
+    $this->createStockLevelField($entity_type, $bundle, 'commerce_stock_level_simple_transaction', [], [], $widget_settings);
 
     // Varations needs a fresh load to load the new fields.
     $this->variation = $entityTypeManager = \Drupal::entityTypeManager()->getStorage($entity_type)->load($this->variations[2]->id());

--- a/modules/field/tests/src/Functional/StockLevelWidgetsTest.php
+++ b/modules/field/tests/src/Functional/StockLevelWidgetsTest.php
@@ -2,6 +2,10 @@
 
 namespace Drupal\Tests\commerce_stock_field\Functional;
 
+use Behat\Mink\Exception\ExpectationException;
+use Drupal\Tests\commerce_stock\Kernel\StockLevelFieldCreationTrait;
+use Drupal\Tests\commerce_stock\Kernel\StockTransactionQueryTrait;
+
 /**
  * Provides tests for the stock level widget.
  *
@@ -9,22 +13,18 @@ namespace Drupal\Tests\commerce_stock_field\Functional;
  */
 class StockLevelWidgetsTest extends StockLevelFieldTestBase {
 
+  use StockTransactionQueryTrait;
+  use StockLevelFieldCreationTrait;
+
   /**
-   * Tests the commerce_stock_level_simple widget.
+   * Tests the default simple transaction widget.
    *
    * @throws \Drupal\Core\Entity\EntityMalformedException
    */
-  public function testWidgetsOnEditProductVariationForm() {
+  public function testSimpleTransactionStockLevelWidget() {
 
     $entity_type = "commerce_product_variation";
     $bundle = 'default';
-    $widget_type = 'commerce_stock_level_simple';
-    $widget_settings = [
-      'entry_system' => 'basic',
-      'transaction_note' => FALSE,
-      'context_fallback' => FALSE,
-    ];
-    $this->configureFormDisplay($widget_type, $widget_settings, $entity_type, $bundle);
     $this->drupalGet($this->variation->toUrl('edit-form'));
     $this->assertSession()->statusCodeEquals(200);
 
@@ -33,26 +33,269 @@ class StockLevelWidgetsTest extends StockLevelFieldTestBase {
       ->fieldExists('commerce_stock_always_in_stock[value]');
     $this->assertSession()
       ->checkboxNotChecked('commerce_stock_always_in_stock[value]');
-    $this->assertSession()->fieldExists($this->fieldName . '[0][stock][adjustment]');
-    $this->assertSession()->pageTextContains('Stock level');
+
+    // Check the defaults.
+    $this->assertSession()->fieldExists($this->fieldName . '[0][adjustment]');
+    $this->assertSession()
+      ->fieldExists($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldDisabled($this->fieldName . '[0][stock_transaction_note]');
+
+    $widget_id = "commerce_stock_level_simple_transaction";
+    $default_note = $this->randomString(200);
+    $widget_settings = [
+      'custom_transaction_note' => FALSE,
+      'default_transaction_note' => $default_note,
+      'step' => '1',
+    ];
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
+    $this->drupalGet($this->variation->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists($this->fieldName . '[0][adjustment]');
+    $this->assertSession()
+      ->fieldExists($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldDisabled($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldValueEquals($this->fieldName . '[0][stock_transaction_note]', $default_note);
+
+    $adjustment = 6;
+    $edit = [
+      $this->fieldName . '[0][adjustment]' => $adjustment,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+    $data = unserialize($transaction->data);
+    $this->assertEquals($adjustment, $transaction->qty);
+    $this->assertEquals($this->adminUser->id(), $transaction->related_uid);
+    $this->assertTrue($default_note, $data['message']);
+
+    $widget_settings = [
+      'custom_transaction_note' => TRUE,
+      'default_transaction_note' => $default_note,
+      'step' => '1',
+    ];
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
+    $this->drupalGet($this->variation->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists($this->fieldName . '[0][adjustment]');
+    $this->assertSession()
+      ->fieldExists($this->fieldName . '[0][stock_transaction_note]');
+    self::setExpectedException(ExpectationException::class);
+    $this->assertSession()
+      ->fieldDisabled($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldValueEquals($this->fieldName . '[0][stock_transaction_note]', $default_note);
+
+    $adjustment = -3;
+    $edit = [
+      $this->fieldName . '[0][adjustment]' => $adjustment,
+      $this->fieldName . '[0][stock_transaction_note]' => 'CustomNote',
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+    $data = unserialize($transaction->data);
+    $this->assertEquals($adjustment, $transaction->qty);
+    $this->assertEquals($this->adminUser->id(), $transaction->related_uid);
+    $this->assertTrue('CustomNote', $data['message']);
+
+  }
+
+  /**
+   * Testing the commerce_stock_level_absolute widget.
+   */
+  public function testAbsoluteStockLevelWidget() {
+
+    $entity_type = "commerce_product_variation";
+    $bundle = 'default';
+    $default_note = $this->randomString(100);
+
+    $widget_id = "commerce_stock_level_absolute";
+    $widget_settings = [
+      'custom_transaction_note' => FALSE,
+      'default_transaction_note' => $default_note,
+      'step' => '1',
+    ];
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
+    $this->drupalGet($this->variation->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists($this->fieldName . '[0][stock_level]');
+    $this->assertSession()
+      ->fieldNotExists($this->fieldName . '[0][adjustment]');
+    $this->assertSession()
+      ->fieldExists($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldDisabled($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldValueEquals($this->fieldName . '[0][stock_transaction_note]', $default_note);
+
+    $stock_level = 15;
+    $edit = [
+      $this->fieldName . '[0][stock_level]' => $stock_level,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+    $data = unserialize($transaction->data);
+    // We setup our variation with an initial stock of 10. So setting the
+    // absolute level to 15 should result in a transaction with 5.
+    $this->assertEquals(5, $transaction->qty);
+    $this->assertEquals($this->adminUser->id(), $transaction->related_uid);
+    $this->assertTrue($default_note, $data['message']);
+
+    // If the absolute stock level is the same as before, it shouldn't trigger
+    // any transaction.
+    $stock_level = 15;
+    $edit = [
+      $this->fieldName . '[0][stock_level]' => $stock_level,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+    $transaction2 = $this->getLastEntityTransaction($this->variation->id());
+    $this->assertEquals($transaction->id, $transaction2->id);
+
+    // Empty absolute stock_level shoudn't trigger any transaction.
+    $stock_level = '';
+    $edit = [
+      $this->fieldName . '[0][stock_level]' => $stock_level,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+    $transaction3 = $this->getLastEntityTransaction($this->variation->id());
+    $this->assertEquals($transaction->id, $transaction3->id);
+
+    $widget_settings = [
+      'custom_transaction_note' => TRUE,
+      'default_transaction_note' => $default_note,
+      'step' => '1',
+    ];
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
+    $this->drupalGet($this->variation->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists($this->fieldName . '[0][stock_level]');
+    $this->assertSession()
+      ->fieldNotExists($this->fieldName . '[0][adjustment]');
+    $this->assertSession()
+      ->fieldExists($this->fieldName . '[0][stock_transaction_note]');
+    self::setExpectedException(ExpectationException::class);
+    $this->assertSession()
+      ->fieldDisabled($this->fieldName . '[0][stock_transaction_note]');
+    $this->assertSession()
+      ->fieldValueEquals($this->fieldName . '[0][stock_transaction_note]', $default_note);
+
+    $stock_level = 5;
+    $edit = [
+      $this->fieldName . '[0][stock_level]' => $stock_level,
+      $this->fieldName . '[0][stock_transaction_note]' => 'CustomNote',
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+
+    $data = unserialize($transaction->data);
+    $this->assertEquals(-10, $transaction->qty);
+    $this->assertEquals($this->adminUser->id(), $transaction->related_uid);
+    $this->assertTrue('CustumNote', $data['message']);
+
+    // Testing that zero value, results in a transaction.
+    $stock_level = 0;
+    $edit = [
+      $this->fieldName . '[0][stock_level]' => $stock_level,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+    $this->assertEquals(-5, $transaction->qty);
+  }
+
+  /**
+   * Testing the commerce_stock_level_absolute widget.
+   */
+  public function testLinkToTransactionFormWidget() {
+    $entity_type = "commerce_product_variation";
+    $bundle = 'default';
+    $widget_id = "commerce_stock_level_transaction_form_link";
+    $widget_settings = [];
+
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
+    $this->drupalGet($this->variation->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists(t('transaction form'));
+    $this->clickLink(t('transaction form'));
+    $this->assertSession()->statusCodeEquals(200);
+    $path = '/admin/commerce/config/stock/transactions2';
+    $this->assertSession()->addressEquals($path);
+  }
+
+  /**
+   * Test the deprecated simple widget.
+   */
+  public function testDeprecatedWidget() {
+    $entity_type = "commerce_product_variation";
+    $bundle = 'default';
+    $widget_id = "commerce_stock_level_simple";
+    $widget_settings = [
+      'entry_system' => 'basic',
+      'transaction_note' => FALSE,
+      'context_fallback' => FALSE,
+    ];
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
+    $this->drupalGet($this->variation->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Ensure the stock part of the form is healty.
+    $this->assertSession()
+      ->fieldExists('commerce_stock_always_in_stock[value]');
+    $this->assertSession()
+      ->checkboxNotChecked('commerce_stock_always_in_stock[value]');
+    $this->assertSession()->fieldExists($this->fieldName . '[0][adjustment]');
+
+    $adjustment = 5;
+    $edit = [
+      $this->fieldName . '[0][adjustment]' => $adjustment,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+    $this->assertEquals($adjustment, $transaction->qty);
+    $this->assertEquals($this->adminUser->id(), $transaction->related_uid);
 
     $widget_settings = [
       'entry_system' => 'simple',
       'transaction_note' => FALSE,
       'context_fallback' => FALSE,
     ];
-    $this->configureFormDisplay($widget_type, $widget_settings, $entity_type, $bundle);
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
     $this->drupalGet($this->variation->toUrl('edit-form'));
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->fieldExists($this->fieldName . '[0][stock][value]');
-    $this->assertSession()->pageTextContains('Total stock level available for this item.');
+    $this->assertSession()->fieldExists($this->fieldName . '[0][stock_level]');
+
+    $stock_level = 20;
+    $edit = [
+      $this->fieldName . '[0][stock_level]' => $stock_level,
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $transaction = $this->getLastEntityTransaction($this->variation->id());
+    // We setup our variation with an initial stock of 15. So setting the
+    // absolute level to 20 should result in a transaction with 5.
+    $this->assertEquals(5, $transaction->qty);
+    $this->assertEquals($this->adminUser->id(), $transaction->related_uid);
 
     $widget_settings = [
       'entry_system' => 'transactions',
       'transaction_note' => FALSE,
       'context_fallback' => FALSE,
     ];
-    $this->configureFormDisplay($widget_type, $widget_settings, $entity_type, $bundle);
+    $this->configureFormDisplay($widget_id, $widget_settings, $entity_type, $bundle);
     $this->drupalGet($this->variation->toUrl('edit-form'));
     $this->assertSession()->statusCodeEquals(200);
     $this->saveHtmlOutput();

--- a/tests/src/Kernel/CommerceStockKernelTestBase.php
+++ b/tests/src/Kernel/CommerceStockKernelTestBase.php
@@ -7,7 +7,7 @@ use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
 /**
  * Base class for Commerce Stock kernel tests.
  */
-class CommerceStockKernelTestBase extends CommerceKernelTestBase {
+abstract class CommerceStockKernelTestBase extends CommerceKernelTestBase {
 
   /**
    * Modules to enable.

--- a/tests/src/Kernel/StockLevelFieldCreationTrait.php
+++ b/tests/src/Kernel/StockLevelFieldCreationTrait.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\commerce_stock\Kernel;
 
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\field\FieldStorageConfigInterface;
 
 /**
  * Provides methods to attach and configure a stock level field.
@@ -74,7 +73,7 @@ trait StockLevelFieldCreationTrait {
   /**
    * Attaches a stock level field to an entity.
    *
-   * @param Drupal\field\Entity\FieldStorageConfigInterface $field_storage
+   * @param Drupal\field\Entity\FieldStorageConfig $field_storage
    *   The field storage.
    * @param string $bundle
    *   The bundle this field will be added to.
@@ -82,7 +81,7 @@ trait StockLevelFieldCreationTrait {
    *   A list of field settings that will be added to the defaults.
    */
   protected function attachStockLevelField(
-    FieldStorageConfigInterface $field_storage,
+    FieldStorageConfig $field_storage,
     $bundle,
     array $field_settings
   ) {

--- a/tests/src/Kernel/StockTransactionQueryTrait.php
+++ b/tests/src/Kernel/StockTransactionQueryTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\Tests\commerce_stock\Kernel;
+
+/**
+ * Provides methods to query the transaction database.
+ */
+trait StockTransactionQueryTrait {
+
+  /**
+   * Return the last transaction for a entity.
+   *
+   * @param string $entity_id
+   *   The id of the entity to.
+   *
+   * @return obj
+   *   The transaction.
+   */
+  protected function getLastEntityTransaction($entity_id) {
+    $connection = \Drupal::database();
+    $query = $connection->select('commerce_stock_transaction', 'txn')
+      ->fields('txn')
+      ->condition('entity_id', $entity_id)
+      ->orderBy('id', 'DESC')
+      ->range(0, 1);
+    return $query
+      ->execute()
+      ->fetchObject();
+  }
+
+  /**
+   * Return the last transaction in the table.
+   *
+   * @return obj
+   *   The transaction.
+   */
+  protected function getLastTransaction() {
+    $connection = \Drupal::database();
+    $query = $connection->select('commerce_stock_transaction', 'txn')
+      ->fields('txn')
+      ->orderBy('id', 'DESC')
+      ->range(0, 1);
+    return $query
+      ->execute()
+      ->fetchObject();
+  }
+
+}


### PR DESCRIPTION
… widgets.

Adding three widgets for stock level field.

- The simple transaction widget is the new default widget.
- Widget settings now allow for setting a default transaction note.
- Hardcoded transaction note removed.
- Widget settings allow for setting the step for the number input.
- We warn the user if he want to use the absolute stock level widget.
- The old "all inclusive" widget is still there and works but is marked deprecated. We should remove it
  before first beta.
- Changes the schema (precision) of the stock level column to meet the commerce core quantity 
  config.
- Adding unit cost, zone and transaction note handling, as well as user_id to the stock level field.
- throws from stock level if we have no location. We have a broken system than.
- Adds some test traits for shared functionality across the modules.
- Adding functional tests for all widgets.

@BBGuy Created a PRfor easier review and discussing the approach.